### PR TITLE
feat: Add credential test and allow tool use

### DIFF
--- a/credentials/OctaveApi.credentials.ts
+++ b/credentials/OctaveApi.credentials.ts
@@ -29,7 +29,7 @@ export class OctaveApi implements ICredentialType {
 		properties: {
 			headers: {
 				'api_key': '={{$credentials.apiKey}}',
-                'x-request-source': 'n8n',
+				'x-request-source': 'n8n',
 			},
 		},
 	};

--- a/credentials/OctaveApi.credentials.ts
+++ b/credentials/OctaveApi.credentials.ts
@@ -1,5 +1,5 @@
 
-import { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type { IAuthenticateGeneric, ICredentialTestRequest, ICredentialType, INodeProperties } from 'n8n-workflow';
 
 export class OctaveApi implements ICredentialType {
     name = 'octaveApi';
@@ -23,4 +23,21 @@ export class OctaveApi implements ICredentialType {
             description: 'The base URL for the Octave API (e.g., https://app.octavehq.com)',
         },
     ];
+
+    authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				'api_key': '={{$credentials.apiKey}}',
+                'x-request-source': 'n8n',
+			},
+		},
+	};
+
+    test: ICredentialTestRequest = {
+		request: {
+			baseURL: '={{ $credentials.baseUrl.replace(new RegExp("/$"), "") }}',
+			url: '/api/v2/agents/list',
+		},
+	};
 }

--- a/nodes/Octave/Octave.node.ts
+++ b/nodes/Octave/Octave.node.ts
@@ -71,6 +71,7 @@ export class Octave implements INodeType {
         defaults: {
             name: 'Octave',
         },
+        usableAsTool: true,
         inputs: [NodeConnectionType.Main],
         outputs: [NodeConnectionType.Main],
         credentials: [


### PR DESCRIPTION
- Adds Credential test
- Sets up Authenticate in Credential so it can be used with the HTTP Request node
- Adds `usableAsTool` so it can be used by AI Agents