### PR TITLE
Add Service resource: 6 CRUD operations

### DIFF
--- a/nodes/Octave/Octave.node.ts
+++ b/nodes/Octave/Octave.node.ts
@@ -22,6 +22,7 @@ import { productOperations } from './descriptions/ProductDescription';
 import { referenceOperations } from './descriptions/ReferenceDescription';
 import { resourceOperations } from './descriptions/ResourceDescription';
 import { solutionOperations } from './descriptions/SolutionDescription';
+import { serviceOperations } from './descriptions/ServiceDescription';
 import { useCaseOperations } from './descriptions/UseCaseDescription';
 import { competitorOperations } from './descriptions/CompetitorDescription';
 import { segmentOperations } from './descriptions/SegmentDescription';
@@ -120,6 +121,13 @@ import { exportedProperties as solutionCreateProperties } from './actions/soluti
 import { exportedProperties as solutionUpdateProperties } from './actions/solution/update.operation';
 import { exportedProperties as solutionGenerateProperties } from './actions/solution/generate.operation';
 import { exportedProperties as solutionDeleteProperties } from './actions/solution/delete.operation';
+// Service
+import { exportedProperties as serviceListProperties } from './actions/service/list.operation';
+import { exportedProperties as serviceGetProperties } from './actions/service/get.operation';
+import { exportedProperties as serviceCreateProperties } from './actions/service/create.operation';
+import { exportedProperties as serviceUpdateProperties } from './actions/service/update.operation';
+import { exportedProperties as serviceGenerateProperties } from './actions/service/generate.operation';
+import { exportedProperties as serviceDeleteProperties } from './actions/service/delete.operation';
 // Resource
 import { exportedProperties as resourceListProperties } from './actions/resource/list.operation';
 import { exportedProperties as resourceGetProperties } from './actions/resource/get.operation';
@@ -212,6 +220,10 @@ export class Octave implements INodeType {
                         value: 'segment',
                     },
                     {
+                        name: 'Service',
+                        value: 'service',
+                    },
+                    {
                         name: 'Solution',
                         value: 'solution',
                     },
@@ -241,6 +253,7 @@ export class Octave implements INodeType {
             ...brandVoiceOperations,
             ...buyingTriggerOperations,
             ...solutionOperations,
+            ...serviceOperations,
             ...resourceOperations,
             ...workflowOperations,
             // Resource Fields (now from individual operation files)
@@ -320,6 +333,12 @@ export class Octave implements INodeType {
             ...solutionUpdateProperties,
             ...solutionGenerateProperties,
             ...solutionDeleteProperties,
+            ...serviceListProperties,
+            ...serviceGetProperties,
+            ...serviceCreateProperties,
+            ...serviceUpdateProperties,
+            ...serviceGenerateProperties,
+            ...serviceDeleteProperties,
             ...resourceListProperties,
             ...resourceGetProperties,
             ...resourceCreateProperties,

--- a/nodes/Octave/actions/router.ts
+++ b/nodes/Octave/actions/router.ts
@@ -105,6 +105,14 @@ import * as solutionUpdateOp from './solution/update.operation';
 import * as solutionGenerateOp from './solution/generate.operation';
 import * as solutionDeleteOp from './solution/delete.operation';
 
+// Service Operations
+import * as serviceListOp from './service/list.operation';
+import * as serviceGetOp from './service/get.operation';
+import * as serviceCreateOp from './service/create.operation';
+import * as serviceUpdateOp from './service/update.operation';
+import * as serviceGenerateOp from './service/generate.operation';
+import * as serviceDeleteOp from './service/delete.operation';
+
 // Resource Operations
 import * as resourceListOp from './resource/list.operation';
 import * as resourceGetOp from './resource/get.operation';
@@ -225,6 +233,14 @@ export async function router(this: IExecuteFunctions, itemIndex: number): Promis
         if (operation === 'update') return solutionUpdateOp.execute.call(this, itemIndex);
         if (operation === 'generate') return solutionGenerateOp.execute.call(this, itemIndex);
         if (operation === 'delete') return solutionDeleteOp.execute.call(this, itemIndex);
+    }
+    else if (resource === 'service') {
+        if (operation === 'list') return serviceListOp.execute.call(this, itemIndex);
+        if (operation === 'get') return serviceGetOp.execute.call(this, itemIndex);
+        if (operation === 'create') return serviceCreateOp.execute.call(this, itemIndex);
+        if (operation === 'update') return serviceUpdateOp.execute.call(this, itemIndex);
+        if (operation === 'generate') return serviceGenerateOp.execute.call(this, itemIndex);
+        if (operation === 'delete') return serviceDeleteOp.execute.call(this, itemIndex);
     }
     else if (resource === 'resource') {
         if (operation === 'list') return resourceListOp.execute.call(this, itemIndex);

--- a/nodes/Octave/actions/service/create.operation.ts
+++ b/nodes/Octave/actions/service/create.operation.ts
@@ -1,0 +1,138 @@
+import { IExecuteFunctions, INodeExecutionData, INodeProperties, NodeOperationError } from 'n8n-workflow';
+import { octaveApiRequest } from '../../transport/OctaveApiRequest';
+import { applyDisplayOptions, parseJsonParameter } from '../utils';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'External name of the service',
+	},
+	{
+		displayName: 'Internal Name',
+		name: 'internalName',
+		type: 'string',
+		default: '',
+		description: 'Internal name of the service (optional)',
+	},
+	{
+		displayName: 'Description',
+		name: 'description',
+		type: 'string',
+		default: '',
+		description: 'Description of the service (optional)',
+	},
+	{
+		displayName: 'Summary',
+		name: 'summary',
+		type: 'string',
+		default: '',
+		description: 'Brief summary of the service (optional)',
+	},
+	{
+		displayName: 'Primary URL',
+		name: 'primaryUrl',
+		type: 'string',
+		default: '',
+		description: 'Primary URL for the service (optional)',
+	},
+	{
+		displayName: 'Deliverables (JSON Array)',
+		name: 'deliverables',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of key deliverables (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Competencies (JSON Array)',
+		name: 'competencies',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of competencies required (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Customer Benefits (JSON Array)',
+		name: 'customerBenefits',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of customer benefits (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Challenges Addressed (JSON Array)',
+		name: 'challengesAddressed',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of challenges addressed (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Comparative Advantage (JSON Array)',
+		name: 'comparativeAdvantage',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of comparative advantages (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Likely Alternative (JSON Array)',
+		name: 'likelyAlternative',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of likely alternatives (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Custom Fields (JSON Array)',
+		name: 'customFields',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of custom fields: [{"title": "field", "value": ["item1", "item2"]}] (optional)',
+		typeOptions: { rows: 5 },
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['service'],
+		operation: ['create'],
+	},
+};
+
+export const exportedProperties: INodeProperties[] = applyDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, itemIndex: number): Promise<INodeExecutionData[][] | null> {
+	const body: Record<string, any> = {};
+
+	body.name = this.getNodeParameter('name', itemIndex) as string;
+	if (!body.name) {
+		throw new NodeOperationError(this.getNode(), 'Name is required to create a service.', { itemIndex });
+	}
+
+	body.internalName = this.getNodeParameter('internalName', itemIndex) as string | undefined;
+	body.description = this.getNodeParameter('description', itemIndex) as string | undefined;
+	body.summary = this.getNodeParameter('summary', itemIndex) as string | undefined;
+	body.primaryUrl = this.getNodeParameter('primaryUrl', itemIndex) as string | undefined;
+	body.deliverables = parseJsonParameter.call(this, 'deliverables', itemIndex, '[]');
+	body.competencies = parseJsonParameter.call(this, 'competencies', itemIndex, '[]');
+	body.customerBenefits = parseJsonParameter.call(this, 'customerBenefits', itemIndex, '[]');
+	body.challengesAddressed = parseJsonParameter.call(this, 'challengesAddressed', itemIndex, '[]');
+	body.comparativeAdvantage = parseJsonParameter.call(this, 'comparativeAdvantage', itemIndex, '[]');
+	body.likelyAlternative = parseJsonParameter.call(this, 'likelyAlternative', itemIndex, '[]');
+	body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
+
+	Object.keys(body).forEach(key => (body[key] === undefined) && delete body[key]);
+
+	const responseData = await octaveApiRequest.call(this, 'POST', '/api/v2/service/create', body);
+
+	const executionData = this.helpers.constructExecutionMetaData(
+		this.helpers.returnJsonArray([responseData]),
+		{ itemData: { item: itemIndex } },
+	);
+	return [executionData];
+}

--- a/nodes/Octave/actions/service/delete.operation.ts
+++ b/nodes/Octave/actions/service/delete.operation.ts
@@ -1,0 +1,37 @@
+import { IExecuteFunctions, INodeExecutionData, INodeProperties, NodeOperationError } from 'n8n-workflow';
+import { octaveApiRequest } from '../../transport/OctaveApiRequest';
+import { applyDisplayOptions } from '../utils';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Service OId',
+		name: 'oId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'OId of the service to delete',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['service'],
+		operation: ['delete'],
+	},
+};
+
+export const exportedProperties: INodeProperties[] = applyDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, itemIndex: number): Promise<INodeExecutionData[][] | null> {
+	const oId = this.getNodeParameter('oId', itemIndex) as string;
+	if (!oId) {
+		throw new NodeOperationError(this.getNode(), 'OId is required.', { itemIndex });
+	}
+
+	const responseData = await octaveApiRequest.call(this, 'DELETE', '/api/v2/service/delete', {}, { oId });
+
+	return [this.helpers.constructExecutionMetaData(
+		this.helpers.returnJsonArray([responseData]),
+		{ itemData: { item: itemIndex } },
+	)];
+}

--- a/nodes/Octave/actions/service/generate.operation.ts
+++ b/nodes/Octave/actions/service/generate.operation.ts
@@ -1,0 +1,124 @@
+import { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n-workflow';
+import { octaveApiRequest } from '../../transport/OctaveApiRequest';
+import { applyDisplayOptions } from '../utils';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Brand Voice OId',
+		name: 'brandVoiceOId',
+		type: 'string',
+		default: '',
+		description: 'Optional brand voice to use for generation',
+	},
+	{
+		displayName: 'Comparative Advantage Input',
+		name: 'comparativeAdvantageInput',
+		type: 'string',
+		default: '',
+		description: 'Input describing the comparative advantage (optional)',
+	},
+	{
+		displayName: 'Likely Alternative Input',
+		name: 'likelyAlternativeInput',
+		type: 'string',
+		default: '',
+		description: 'Input describing the likely alternative (optional)',
+	},
+	{
+		displayName: 'Service Generation Requests',
+		name: 'services',
+		type: 'collection',
+		placeholder: 'Add Service',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: [{}],
+		description: 'Array of service generation requests. Each generates one service.',
+		options: [
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+				description: 'Optional name for the service - if provided, will be used as the entity name',
+				placeholder: 'Managed Analytics Onboarding',
+			},
+			{
+				displayName: 'Sources',
+				name: 'sources',
+				type: 'fixedCollection',
+				placeholder: 'Add Source',
+				typeOptions: {
+					multipleValues: true,
+				},
+				default: {},
+				description: 'Source materials to generate the service from (at least one required)',
+				options: [
+					{
+						displayName: 'Source',
+						name: 'source',
+						values: [
+							{
+								displayName: 'Type',
+								name: 'type',
+								type: 'options',
+								options: [
+									{ name: 'Text', value: 'TEXT', description: 'Text-based source material' },
+									{ name: 'URL', value: 'URL', description: 'URL-based source material' },
+								],
+								default: 'TEXT',
+								description: 'The type of source material',
+							},
+							{
+								displayName: 'Value',
+								name: 'value',
+								type: 'string',
+								default: '',
+								description: 'The source content (text or URL)',
+								placeholder: 'Onboarding engagement for enterprise customers',
+								typeOptions: { rows: 3 },
+							},
+						],
+					},
+				],
+			},
+		],
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['service'],
+		operation: ['generate'],
+	},
+};
+
+export const exportedProperties: INodeProperties[] = applyDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, itemIndex: number): Promise<INodeExecutionData[][] | null> {
+	const body: Record<string, any> = {};
+
+	body.brandVoiceOId = this.getNodeParameter('brandVoiceOId', itemIndex) as string | undefined;
+	body.comparativeAdvantageInput = this.getNodeParameter('comparativeAdvantageInput', itemIndex) as string | undefined;
+	body.likelyAlternativeInput = this.getNodeParameter('likelyAlternativeInput', itemIndex) as string | undefined;
+
+	const servicesRaw = this.getNodeParameter('services', itemIndex) as Array<{
+		name?: string;
+		sources: { source?: Array<{ type: 'TEXT' | 'URL'; value: string }> };
+	}>;
+
+	body.services = servicesRaw.map(service => ({
+		name: service.name,
+		sources: service.sources?.source || [],
+	}));
+
+	Object.keys(body).forEach(key => (body[key] === undefined) && delete body[key]);
+
+	const responseData = await octaveApiRequest.call(this, 'POST', '/api/v2/service/generate', body);
+
+	const executionData = this.helpers.constructExecutionMetaData(
+		this.helpers.returnJsonArray([responseData]),
+		{ itemData: { item: itemIndex } },
+	);
+	return [executionData];
+}

--- a/nodes/Octave/actions/service/get.operation.ts
+++ b/nodes/Octave/actions/service/get.operation.ts
@@ -1,0 +1,29 @@
+import { IExecuteFunctions, INodeProperties } from 'n8n-workflow';
+import { octaveApiRequest } from '../../transport/OctaveApiRequest';
+import { applyDisplayOptions } from '../utils';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Service OId',
+		name: 'oId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'The OId of the service to retrieve',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['service'],
+		operation: ['get'],
+	},
+};
+
+export const exportedProperties: INodeProperties[] = applyDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, itemIndex: number): Promise<any> {
+	const oId = this.getNodeParameter('oId', itemIndex) as string;
+	const response = await octaveApiRequest.call(this, 'GET', '/api/v2/service/get', {}, { oId });
+	return [this.helpers.returnJsonArray(response)];
+}

--- a/nodes/Octave/actions/service/list.operation.ts
+++ b/nodes/Octave/actions/service/list.operation.ts
@@ -1,0 +1,60 @@
+import { IExecuteFunctions, INodeProperties } from 'n8n-workflow';
+import { octaveApiRequest } from '../../transport/OctaveApiRequest';
+import { applyDisplayOptions } from '../utils';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Text Search',
+		name: 'text',
+		type: 'string',
+		default: '',
+		description: 'Text search query',
+	},
+	{
+		displayName: 'Service OId',
+		name: 'serviceOId',
+		type: 'string',
+		default: '',
+		description: 'Filter list by a specific Service OId',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		typeOptions: { minValue: 1 },
+		default: 50,
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Offset',
+		name: 'offset',
+		type: 'number',
+		default: 0,
+		description: 'Number of results to skip',
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['service'],
+		operation: ['list'],
+	},
+};
+
+export const exportedProperties: INodeProperties[] = applyDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, itemIndex: number): Promise<any> {
+	const text = this.getNodeParameter('text', itemIndex) as string;
+	const serviceOId = this.getNodeParameter('serviceOId', itemIndex) as string;
+	const limit = this.getNodeParameter('limit', itemIndex) as number;
+	const offset = this.getNodeParameter('offset', itemIndex) as number;
+
+	const qs: any = {};
+	if (text) qs.text = text;
+	if (serviceOId) qs.serviceOId = serviceOId;
+	if (limit) qs.limit = limit;
+	if (offset) qs.offset = offset;
+
+	const response = await octaveApiRequest.call(this, 'GET', '/api/v2/service/list', {}, qs);
+	return [this.helpers.returnJsonArray(response.data || [])];
+}

--- a/nodes/Octave/actions/service/update.operation.ts
+++ b/nodes/Octave/actions/service/update.operation.ts
@@ -1,0 +1,146 @@
+import { IExecuteFunctions, INodeExecutionData, INodeProperties, NodeOperationError } from 'n8n-workflow';
+import { octaveApiRequest } from '../../transport/OctaveApiRequest';
+import { applyDisplayOptions, parseJsonParameter } from '../utils';
+
+const properties: INodeProperties[] = [
+	{
+		displayName: 'Service OId',
+		name: 'oId',
+		type: 'string',
+		required: true,
+		default: '',
+		description: 'OId of the service to update',
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		default: '',
+		description: 'External name of the service (optional)',
+	},
+	{
+		displayName: 'Internal Name',
+		name: 'internalName',
+		type: 'string',
+		default: '',
+		description: 'Internal name of the service (optional)',
+	},
+	{
+		displayName: 'Description',
+		name: 'description',
+		type: 'string',
+		default: '',
+		description: 'Description of the service (optional)',
+	},
+	{
+		displayName: 'Summary',
+		name: 'summary',
+		type: 'string',
+		default: '',
+		description: 'Brief summary of the service (optional)',
+	},
+	{
+		displayName: 'Primary URL',
+		name: 'primaryUrl',
+		type: 'string',
+		default: '',
+		description: 'Primary URL for the service (optional)',
+	},
+	{
+		displayName: 'Deliverables (JSON Array)',
+		name: 'deliverables',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of key deliverables (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Competencies (JSON Array)',
+		name: 'competencies',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of competencies required (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Customer Benefits (JSON Array)',
+		name: 'customerBenefits',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of customer benefits (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Challenges Addressed (JSON Array)',
+		name: 'challengesAddressed',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of challenges addressed (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Comparative Advantage (JSON Array)',
+		name: 'comparativeAdvantage',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of comparative advantages (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Likely Alternative (JSON Array)',
+		name: 'likelyAlternative',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of likely alternatives (optional)',
+		typeOptions: { rows: 3 },
+	},
+	{
+		displayName: 'Custom Fields (JSON Array)',
+		name: 'customFields',
+		type: 'json',
+		default: '[]',
+		description: 'JSON array of custom fields: [{"title": "field", "value": ["item1", "item2"]}] (optional)',
+		typeOptions: { rows: 5 },
+	},
+];
+
+const displayOptions = {
+	show: {
+		resource: ['service'],
+		operation: ['update'],
+	},
+};
+
+export const exportedProperties: INodeProperties[] = applyDisplayOptions(displayOptions, properties);
+
+export async function execute(this: IExecuteFunctions, itemIndex: number): Promise<INodeExecutionData[][] | null> {
+	const body: Record<string, any> = {};
+
+	body.oId = this.getNodeParameter('oId', itemIndex) as string;
+	if (!body.oId) {
+		throw new NodeOperationError(this.getNode(), 'Service OId is required to update a service.', { itemIndex });
+	}
+
+	body.name = this.getNodeParameter('name', itemIndex) as string | undefined;
+	body.internalName = this.getNodeParameter('internalName', itemIndex) as string | undefined;
+	body.description = this.getNodeParameter('description', itemIndex) as string | undefined;
+	body.summary = this.getNodeParameter('summary', itemIndex) as string | undefined;
+	body.primaryUrl = this.getNodeParameter('primaryUrl', itemIndex) as string | undefined;
+	body.deliverables = parseJsonParameter.call(this, 'deliverables', itemIndex, '[]');
+	body.competencies = parseJsonParameter.call(this, 'competencies', itemIndex, '[]');
+	body.customerBenefits = parseJsonParameter.call(this, 'customerBenefits', itemIndex, '[]');
+	body.challengesAddressed = parseJsonParameter.call(this, 'challengesAddressed', itemIndex, '[]');
+	body.comparativeAdvantage = parseJsonParameter.call(this, 'comparativeAdvantage', itemIndex, '[]');
+	body.likelyAlternative = parseJsonParameter.call(this, 'likelyAlternative', itemIndex, '[]');
+	body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
+
+	Object.keys(body).forEach(key => (body[key] === undefined) && delete body[key]);
+
+	const responseData = await octaveApiRequest.call(this, 'POST', '/api/v2/service/update', body);
+
+	const executionData = this.helpers.constructExecutionMetaData(
+		this.helpers.returnJsonArray([responseData]),
+		{ itemData: { item: itemIndex } },
+	);
+	return [executionData];
+}

--- a/nodes/Octave/descriptions/ServiceDescription.ts
+++ b/nodes/Octave/descriptions/ServiceDescription.ts
@@ -1,0 +1,54 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const serviceOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['service'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a new service',
+				action: 'Create a service',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a service',
+				action: 'Delete a service',
+			},
+			{
+				name: 'Generate',
+				value: 'generate',
+				description: 'Generate a service from source materials using AI',
+				action: 'Generate a service',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Get a service by OId',
+				action: 'Get a service',
+			},
+			{
+				name: 'List',
+				value: 'list',
+				description: 'List services with optional filtering',
+				action: 'List services',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update an existing service',
+				action: 'Update a service',
+			},
+		],
+		default: 'list',
+	},
+];


### PR DESCRIPTION
## Summary
- Wires the new `/api/v2/service/*` endpoints as a first-class n8n resource, mirroring Product/Solution.
- Adds `nodes/Octave/actions/service/{list,get,create,update,generate,delete}.operation.ts`.
- Adds `nodes/Octave/descriptions/ServiceDescription.ts` with the 6-operation selector.
- Registers imports and branches in `actions/router.ts` and properties/descriptions in `Octave.node.ts`.

## Test plan
- [ ] `tsc --noEmit` passes
- [ ] `gulp build:icons` completes
- [ ] Resource dropdown in n8n shows "Service" with all 6 operations
- [ ] Optional: smoke a Create + Get in a local n8n against localhost octave-app

🤖 Generated with [Claude Code](https://claude.com/claude-code)