### PR TITLE
Bump version to 1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-octavehq",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-octavehq",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/parser": "~8.32.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-octavehq",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Octave is the AI-powered messaging brain for B2B go-to-market teams, helping articulate product value, synthesize customer interaction data, and deploy consistent, effective messaging across all channels.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Releases the n8n verification feedback fixes from #12 as v1.6.2.

Once merged, the v1.6.2 tag will be pushed to point at the merged commit, and v1.6.0 / v1.6.1 backfill tags will be pushed alongside (so future n8n diff reviews can resolve them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates the package version metadata in `package.json` and `package-lock.json`, with no runtime or dependency changes.
> 
> **Overview**
> Bumps the `n8n-nodes-octavehq` package version from `1.6.1` to `1.6.2` in both `package.json` and `package-lock.json` to cut a new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f724e907a5e5f9aaa348b9481a6906fd5e26e16e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->