### PR TITLE
Add npm publish workflow with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Lint (prepublish config)
+        run: npx eslint -c .eslintrc.prepublish.js nodes credentials package.json
+
+      - name: Publish to npm with provenance
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow to publish `n8n-nodes-octavehq` to npm with [npm provenance](https://docs.npmjs.com/generating-provenance-statements) attestation. Required by the n8n verified-node policy effective **2026-05-01**.

## What it does
- Triggers on push of any `v*` tag (and supports manual dispatch as a backup)
- Sets up Node 20 with the npmjs.org registry
- Runs `npm ci` → `npm run build` → prepublish lint → `npm publish --provenance --access public`
- Uses OIDC (`id-token: write`) to generate the provenance statement, paired with the `NPM_TOKEN` automation secret for the publish auth

## Required setup before merging
1. Create an **automation token** on npmjs.com under the account that owns `n8n-nodes-octavehq`
2. Add it to this repo's secrets as `NPM_TOKEN`
3. (Optional but recommended) Make sure the npm account has 2FA set to "Authorization only" rather than "Authorization and writes" — automation tokens bypass the latter, but it's worth confirming

## Release flow after merge
1. Bump version on a branch (`npm version patch` etc.) and merge to main
2. Tag the merged commit (`git tag v1.6.3 <SHA> && git push origin v1.6.3`)
3. Workflow runs automatically and publishes with provenance

## Test plan
- [ ] After merge, add `NPM_TOKEN` secret
- [ ] Trigger workflow via `workflow_dispatch` against `main` to confirm build/lint work end-to-end (will fail at `npm publish` because 1.6.2 is already up — that's fine, just check earlier steps pass)
- [ ] On the next real release, push a new tag and confirm the workflow publishes with the provenance badge visible on the npm package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces automated publishing of releases to npm using repository secrets and OIDC provenance; misconfiguration could publish unintended versions or fail releases.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/publish.yml`) to **automate npm releases** on `v*` tags (or manual `workflow_dispatch`).
> 
> The job installs deps, runs `npm run build`, performs a prepublish ESLint pass, and then runs `npm publish --provenance --access public` using `NPM_TOKEN` and `id-token: write` for provenance attestation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d330969f7d0db7e754b320dc6d7fad1c5e58507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->