### PR TITLE
Re-land smoke runner + dependabot config (relands #16)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-# Copy to .env and fill in. Used by the read-only smoke runner.
-# Run with:  node --env-file=.env test-runner.js  (Node 20.12+)
-# Or:        OCTAVE_API_KEY=... node test-runner.js
+# Copy to .env and fill in. The smoke runner loads .env automatically;
+# values here override anything already in your shell environment.
+# Run with:  npm test
+# Or:        OCTAVE_API_KEY=... npm test
 
 OCTAVE_API_KEY=
 OCTAVE_BASE_URL=https://app.octavehq.com

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Copy to .env and fill in. Used by the read-only smoke runner.
+# Run with:  node --env-file=.env test-runner.js  (Node 20.12+)
+# Or:        OCTAVE_API_KEY=... node test-runner.js
+
+OCTAVE_API_KEY=
+OCTAVE_BASE_URL=https://app.octavehq.com
+# Set DEBUG=true for verbose request/response logging
+# DEBUG=true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    ignore:
+      # uuid <14 (GHSA-w5hq-g745-h8pq) is pulled in transitively by
+      # n8n-workflow, which currently pins uuid@10. There is no patched
+      # version reachable until n8n upgrades the dependency upstream,
+      # and uuid is not bundled into our published dist/ tarball
+      # (n8n-workflow is a peerDependency, so consumers receive
+      # whatever uuid n8n itself ships).
+      - dependency-name: "uuid"
+        versions: ["<14.0.0"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .DS_Store
+.env
 .tmp
 tmp
 dist

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "lint": "eslint nodes credentials package.json",
     "lintfix": "eslint nodes credentials package.json --fix",
     "test": "node test-runner.js",
-    "test:env": "node --env-file=.env test-runner.js",
     "prepublishOnly": "npm run build && npm run lint -- -c .eslintrc.prepublish.js nodes credentials package.json"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "format": "prettier nodes credentials --write",
     "lint": "eslint nodes credentials package.json",
     "lintfix": "eslint nodes credentials package.json --fix",
+    "test": "node test-runner.js",
+    "test:env": "node --env-file=.env test-runner.js",
     "prepublishOnly": "npm run build && npm run lint -- -c .eslintrc.prepublish.js nodes credentials package.json"
   },
   "files": [

--- a/test-runner.js
+++ b/test-runner.js
@@ -24,6 +24,41 @@
  * Exits 1 on any failure.
  */
 
+// Node's --env-file does not override existing process.env values, so a
+// stale OCTAVE_API_KEY in the shell will silently shadow .env. Parse .env
+// ourselves, prefer its values, and warn loudly on any mismatch so the
+// source of each value is unambiguous.
+const fs = require('node:fs');
+const path = require('node:path');
+
+function loadDotenv(envPath) {
+	if (!fs.existsSync(envPath)) return {};
+	const parsed = {};
+	const text = fs.readFileSync(envPath, 'utf8');
+	for (const rawLine of text.split(/\r?\n/)) {
+		const line = rawLine.trim();
+		if (!line || line.startsWith('#')) continue;
+		const eq = line.indexOf('=');
+		if (eq <= 0) continue;
+		const key = line.slice(0, eq).trim();
+		let value = line.slice(eq + 1).trim();
+		if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+			value = value.slice(1, -1);
+		}
+		parsed[key] = value;
+	}
+	return parsed;
+}
+
+const dotenv = loadDotenv(path.join(process.cwd(), '.env'));
+for (const key of ['OCTAVE_API_KEY', 'OCTAVE_BASE_URL']) {
+	if (dotenv[key] === undefined) continue;
+	if (process.env[key] && process.env[key] !== dotenv[key]) {
+		console.warn(`⚠️  ${key} in shell env differs from .env — using the .env value. Run \`unset ${key}\` to silence this warning.`);
+	}
+	process.env[key] = dotenv[key];
+}
+
 const API_KEY = process.env.OCTAVE_API_KEY;
 const BASE_URL = (process.env.OCTAVE_BASE_URL || 'https://app.octavehq.com').replace(/\/$/, '');
 const DEBUG = process.env.DEBUG === 'true';

--- a/test-runner.js
+++ b/test-runner.js
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+
+/**
+ * Read-only smoke test runner for n8n-nodes-octavehq.
+ *
+ * Hits the same Octave API endpoints the node calls, using the same
+ * auth headers (api_key + x-request-source: n8n). Verifies that:
+ *   - Auth is accepted
+ *   - Each list endpoint returns 200 with the expected envelope shape
+ *   - For each resource that returned at least one item, the matching
+ *     get endpoint resolves the first item's oId
+ *
+ * Read-only by design — never creates, updates, deletes, or generates.
+ * Safe to point at any workspace.
+ *
+ * Usage:
+ *   OCTAVE_API_KEY=... node test-runner.js
+ *   OCTAVE_API_KEY=... OCTAVE_BASE_URL=https://app.octavehq.com node test-runner.js
+ *   DEBUG=true OCTAVE_API_KEY=... node test-runner.js
+ *
+ * Or copy .env.example to .env and run with --env-file (Node 20.12+):
+ *   node --env-file=.env test-runner.js
+ *
+ * Exits 1 on any failure.
+ */
+
+const API_KEY = process.env.OCTAVE_API_KEY;
+const BASE_URL = (process.env.OCTAVE_BASE_URL || 'https://app.octavehq.com').replace(/\/$/, '');
+const DEBUG = process.env.DEBUG === 'true';
+
+if (!API_KEY) {
+	console.error('❌ OCTAVE_API_KEY is required. Set it in your environment or .env file.');
+	process.exit(1);
+}
+
+const HEADERS = {
+	api_key: API_KEY,
+	'x-request-source': 'n8n',
+	Accept: 'application/json',
+};
+
+const RESOURCES = [
+	{ name: 'agent', listPath: '/api/v2/agents/list', getPath: '/api/v2/agents/get' },
+	{ name: 'brandVoice', listPath: '/api/v2/brand-voice/list' },
+	{ name: 'buyingTrigger', listPath: '/api/v2/buying-trigger/list' },
+	{ name: 'competitor', listPath: '/api/v2/competitor/list' },
+	{ name: 'persona', listPath: '/api/v2/persona/list' },
+	{ name: 'playbook', listPath: '/api/v2/playbook/list' },
+	{ name: 'product', listPath: '/api/v2/product/list' },
+	{ name: 'proofPoint', listPath: '/api/v2/proof-point/list' },
+	{ name: 'reference', listPath: '/api/v2/reference/list' },
+	{ name: 'resource', listPath: '/api/v2/resource/list' },
+	{ name: 'segment', listPath: '/api/v2/segment/list' },
+	{ name: 'service', listPath: '/api/v2/service/list' },
+	{ name: 'solution', listPath: '/api/v2/solution/list' },
+	{ name: 'useCase', listPath: '/api/v2/use-case/list' },
+];
+
+const results = { passed: 0, failed: 0, tests: [] };
+
+function debug(message, data) {
+	if (DEBUG) {
+		console.log(`  🔍 ${message}`);
+		if (data !== undefined) console.log(`     ${JSON.stringify(data, null, 2).split('\n').join('\n     ')}`);
+	}
+}
+
+async function octaveRequest(method, path, query) {
+	const url = new URL(`${BASE_URL}${path}`);
+	if (query) {
+		for (const [k, v] of Object.entries(query)) {
+			if (v !== undefined && v !== null) url.searchParams.set(k, String(v));
+		}
+	}
+	debug(`${method} ${url.toString()}`);
+	const res = await fetch(url, { method, headers: HEADERS });
+	const text = await res.text();
+	let body;
+	try {
+		body = text ? JSON.parse(text) : null;
+	} catch {
+		body = text;
+	}
+	if (!res.ok) {
+		const detail = typeof body === 'object' ? JSON.stringify(body) : body;
+		throw new Error(`HTTP ${res.status} on ${method} ${path}: ${detail}`);
+	}
+	return body;
+}
+
+async function runTest(name, fn) {
+	process.stdout.write(`• ${name} ... `);
+	try {
+		const detail = await fn();
+		console.log(`✅ ${detail || 'ok'}`);
+		results.passed++;
+		results.tests.push({ name, status: 'passed' });
+	} catch (err) {
+		console.log(`❌ ${err.message}`);
+		results.failed++;
+		results.tests.push({ name, status: 'failed', error: err.message });
+	}
+}
+
+function assertListShape(body, resourceName) {
+	if (!body || typeof body !== 'object') {
+		throw new Error(`expected object response, got ${typeof body}`);
+	}
+	if (!Array.isArray(body.data)) {
+		throw new Error(`expected body.data to be an array, got ${typeof body.data}`);
+	}
+	debug(`${resourceName} list returned ${body.data.length} item(s); hasNext=${body.hasNext}`);
+}
+
+async function main() {
+	console.log(`Octave smoke runner — ${BASE_URL}`);
+	console.log(`Read-only mode: list + get endpoints only\n`);
+
+	// Auth check via agents/list — fails fast on bad key
+	await runTest('auth: GET /api/v2/agents/list', async () => {
+		const body = await octaveRequest('GET', '/api/v2/agents/list', { limit: 1 });
+		assertListShape(body, 'agent');
+		return `${body.data.length} item(s)`;
+	});
+
+	// agent/languages — separate non-list endpoint worth covering
+	await runTest('agent: GET /api/v2/agents/languages', async () => {
+		const body = await octaveRequest('GET', '/api/v2/agents/languages');
+		if (!body) throw new Error('empty response');
+		return 'ok';
+	});
+
+	for (const resource of RESOURCES) {
+		let firstOId;
+		await runTest(`${resource.name}: GET ${resource.listPath}`, async () => {
+			const body = await octaveRequest('GET', resource.listPath, { limit: 5, offset: 0 });
+			assertListShape(body, resource.name);
+			if (body.data.length > 0) firstOId = body.data[0].oId;
+			return `${body.data.length} item(s)`;
+		});
+
+		if (resource.getPath && firstOId) {
+			await runTest(`${resource.name}: GET ${resource.getPath}?oId=…`, async () => {
+				const body = await octaveRequest('GET', resource.getPath, { oId: firstOId });
+				if (!body || typeof body !== 'object') throw new Error('expected object response');
+				return `oId=${firstOId.slice(0, 8)}…`;
+			});
+		}
+	}
+
+	console.log(`\n${results.passed} passed, ${results.failed} failed`);
+	process.exit(results.failed > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+	console.error(`\n❌ Runner crashed: ${err.message}`);
+	if (DEBUG) console.error(err.stack);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
Re-lands PR #16's content on main. PR #16 was opened with base = `fix/remove-package-overrides` (stacked on the now-merged PR #15) and ended up merging into that stale branch instead of `main`. This PR brings the same 5-file diff to `main` directly.

## Contents
- `test-runner.js` — read-only smoke runner covering all 14 list endpoints + agent get/languages, native fetch, no new deps. Auto-loads `.env` (warns when shell env shadows it).
- `.env.example` — template
- `.gitignore` — adds `.env`
- `package.json` — adds `npm test` script
- `.github/dependabot.yml` — ignores `uuid <14` (upstream-blocked by n8n-workflow pinning uuid@10 across all current versions). This silences the Dependabot security update job that has been failing on `main`.

## Verified
- `npm test` against `https://app.octavehq.com` → 17 passed, 0 failed
- Once merged + the `v1.6.3` tag is pushed, the publish workflow will fire for the first time and publish with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone, read-only test script plus repo hygiene/config files; no runtime node behavior or published `dist` code is modified.
> 
> **Overview**
> Adds a standalone, read-only `test-runner.js` smoke runner (wired to `npm test`) that calls the Octave API list endpoints (and a couple of agent endpoints) to quickly validate API key auth and response shape.
> 
> Introduces `.env.example` and ignores local `.env` files to simplify running the smoke tests, and adds a Dependabot config to run weekly npm checks while ignoring the upstream-blocked `uuid <14` advisory noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 647f04263496bc53fb64632d05680df50b2af914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->