### PR TITLE
Ignore uuid entirely in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,12 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     ignore:
-      # uuid <14 (GHSA-w5hq-g745-h8pq) is pulled in transitively by
-      # n8n-workflow, which currently pins uuid@10. There is no patched
-      # version reachable until n8n upgrades the dependency upstream,
-      # and uuid is not bundled into our published dist/ tarball
-      # (n8n-workflow is a peerDependency, so consumers receive
-      # whatever uuid n8n itself ships).
+      # uuid is pulled in transitively by n8n-workflow, which currently
+      # pins uuid@10 across every published version. There is no
+      # resolvable upgrade path (uuid >=14 conflicts with the
+      # n8n-workflow peer pin), so Dependabot security updates fail.
+      # uuid is not bundled into our published dist/ tarball —
+      # n8n-workflow is a peerDependency, so consumers receive whatever
+      # uuid n8n itself ships. Ignoring all uuid versions until n8n
+      # upgrades upstream; revisit when their pin moves.
       - dependency-name: "uuid"
-        versions: ["<14.0.0"]


### PR DESCRIPTION
## Summary
The dependabot security update job for `uuid` is still failing on `main` despite the ignore rule from #17. The previous config ignored versions `<14.0.0`, which filtered out *update proposals* below 14 but did not stop Dependabot from trying to bump `uuid@10` → `uuid@14` to satisfy the security advisory — that upgrade is impossible because n8n-workflow pins `uuid@10`, so the run keeps exiting `update_not_possible`.

Dropping the `versions:` clause ignores the dependency entirely. Per GitHub's [Dependabot docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore--):

> If the `dependency-name` field is set without specifying versions, the ignore condition will apply to all versions of that dependency.

That is the right behavior here: there is no resolvable uuid upgrade until n8n-workflow bumps the pin upstream, and `uuid` is not bundled in our published `dist/` tarball anyway (n8n-workflow is a peerDependency, so n8n Cloud supplies its own copy at runtime).

## Manual cleanup after merge
GitHub does not auto-close existing alerts when ignore rules change. Dismiss [alert #36](https://github.com/octavehq/octave-n8n/security/dependabot/36) manually with reason **"Risk tolerated"** so the badge clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects dependency update automation; main impact is suppressing `uuid` security/update PRs until the upstream peer dependency pin changes.
> 
> **Overview**
> Updates `.github/dependabot.yml` to **ignore `uuid` entirely** (removing the version filter) so Dependabot stops attempting unresolvable security upgrades caused by the `n8n-workflow` peer dependency pin.
> 
> Also revises the inline comment to document why `uuid` updates are being ignored and when to revisit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 126e869f90dc93dbf48811112e5bdf75c6ad2d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->