### PR TITLE
Refresh library entity schemas across n8n create/update operations

### DIFF
--- a/nodes/Octave/actions/buyingTrigger/create.operation.ts
+++ b/nodes/Octave/actions/buyingTrigger/create.operation.ts
@@ -43,8 +43,8 @@ const properties: INodeProperties[] = [
 		typeOptions: { rows: 3 },
 	},
 	{
-		displayName: 'What\'s the Cost of Inaction (JSON Array)',
-		name: 'whatsTheCostOfInaction',
+		displayName: 'Cost of Inaction (JSON Array)',
+		name: 'costOfInaction',
 		type: 'json',
 		default: '[]',
 		description: 'String array — consequences of waiting while this trigger is in play',
@@ -122,7 +122,7 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
 	const description = this.getNodeParameter('description', itemIndex) as string;
 	if (description) body.description = description;
 
-	const arrFields = ['whyThisCreatesUrgency', 'whoFeelsThisMost', 'whatsTheCostOfInaction', 'howWeHelpInThisMoment'];
+	const arrFields = ['whyThisCreatesUrgency', 'whoFeelsThisMost', 'costOfInaction', 'howWeHelpInThisMoment'];
 	for (const f of arrFields) {
 		const v = parseJsonParameter.call(this, f, itemIndex, '[]');
 		if (Array.isArray(v) && v.length > 0) body[f] = v;

--- a/nodes/Octave/actions/buyingTrigger/update.operation.ts
+++ b/nodes/Octave/actions/buyingTrigger/update.operation.ts
@@ -48,8 +48,8 @@ const properties: INodeProperties[] = [
 		typeOptions: { rows: 3 },
 	},
 	{
-		displayName: 'What\'s the Cost of Inaction (JSON Array)',
-		name: 'whatsTheCostOfInaction',
+		displayName: 'Cost of Inaction (JSON Array)',
+		name: 'costOfInaction',
 		type: 'json',
 		default: '[]',
 		typeOptions: { rows: 3 },
@@ -94,7 +94,7 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
 	const description = this.getNodeParameter('description', itemIndex) as string;
 	if (description) body.description = description;
 
-	const arrFields = ['whyThisCreatesUrgency', 'whoFeelsThisMost', 'whatsTheCostOfInaction', 'howWeHelpInThisMoment', 'customFields'];
+	const arrFields = ['whyThisCreatesUrgency', 'whoFeelsThisMost', 'costOfInaction', 'howWeHelpInThisMoment', 'customFields'];
 	for (const f of arrFields) {
 		const v = parseJsonParameter.call(this, f, itemIndex, '[]');
 		if (Array.isArray(v) && v.length > 0) body[f] = v;

--- a/nodes/Octave/actions/competitor/create.operation.ts
+++ b/nodes/Octave/actions/competitor/create.operation.ts
@@ -36,35 +36,35 @@ const properties: INodeProperties[] = [
         description: 'Internal name of the competitor (optional)',
     },
     {
-        displayName: 'Business Model (JSON Array)',
-        name: 'businessModel',
+        displayName: 'How They Position (JSON Array)',
+        name: 'howTheyPosition',
         type: 'json',
         default: '[]',
-        description: 'JSON array of business model descriptions (optional)',
+        description: 'JSON array — how the competitor positions themselves: their narrative, messaging, and market story; the pitch they take to market (optional)',
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Comparative Strengths (JSON Array)',
-        name: 'comparativeStrengths',
+        displayName: 'Our Key Differentiators (JSON Array)',
+        name: 'ourKeyDifferentiators',
         type: 'json',
         default: '[]',
-        description: 'JSON array of comparative strengths (optional)',
+        description: 'JSON array — concrete, observable, tactical points of differentiation we lead with against this competitor (optional)',
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Comparative Weaknesses (JSON Array)',
-        name: 'comparativeWeaknesses',
+        displayName: 'Competitor Strengths (JSON Array)',
+        name: 'competitorStrengths',
         type: 'json',
         default: '[]',
-        description: 'JSON array of comparative weaknesses (optional)',
+        description: 'JSON array — where this competitor genuinely excels (optional)',
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Key Differentiators (JSON Array)',
-        name: 'keyDifferentiators',
+        displayName: 'Competitor Weaknesses (JSON Array)',
+        name: 'competitorWeaknesses',
         type: 'json',
         default: '[]',
-        description: 'JSON array of key differentiators (optional)',
+        description: 'JSON array — where this competitor falls short (optional)',
         typeOptions: { rows: 3 },
     },
     {
@@ -76,19 +76,11 @@ const properties: INodeProperties[] = [
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Customers We Won (JSON Array)',
-        name: 'customersWeWon',
+        displayName: 'Reasons We Lose (JSON Array)',
+        name: 'reasonsWeLose',
         type: 'json',
         default: '[]',
-        description: 'JSON array of customers we won from this competitor (optional)',
-        typeOptions: { rows: 3 },
-    },
-    {
-        displayName: 'Customers We Switched (JSON Array)',
-        name: 'customersWeSwitched',
-        type: 'json',
-        default: '[]',
-        description: 'JSON array of customers we switched to this competitor (optional)',
+        description: 'JSON array — deal-level dynamics for why customers might choose them when both are evaluated (optional)',
         typeOptions: { rows: 3 },
     },
     {
@@ -155,13 +147,12 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.primaryOfferingOId = this.getNodeParameter('primaryOfferingOId', itemIndex) as string | undefined;
     body.description = this.getNodeParameter('description', itemIndex) as string | undefined;
     body.internalName = this.getNodeParameter('internalName', itemIndex) as string | undefined;
-    body.businessModel = parseJsonParameter.call(this, 'businessModel', itemIndex, '[]');
-    body.comparativeStrengths = parseJsonParameter.call(this, 'comparativeStrengths', itemIndex, '[]');
-    body.comparativeWeaknesses = parseJsonParameter.call(this, 'comparativeWeaknesses', itemIndex, '[]');
-    body.keyDifferentiators = parseJsonParameter.call(this, 'keyDifferentiators', itemIndex, '[]');
+    body.howTheyPosition = parseJsonParameter.call(this, 'howTheyPosition', itemIndex, '[]');
+    body.ourKeyDifferentiators = parseJsonParameter.call(this, 'ourKeyDifferentiators', itemIndex, '[]');
+    body.competitorStrengths = parseJsonParameter.call(this, 'competitorStrengths', itemIndex, '[]');
+    body.competitorWeaknesses = parseJsonParameter.call(this, 'competitorWeaknesses', itemIndex, '[]');
     body.reasonsWeWin = parseJsonParameter.call(this, 'reasonsWeWin', itemIndex, '[]');
-    body.customersWeWon = parseJsonParameter.call(this, 'customersWeWon', itemIndex, '[]');
-    body.customersWeSwitched = parseJsonParameter.call(this, 'customersWeSwitched', itemIndex, '[]');
+    body.reasonsWeLose = parseJsonParameter.call(this, 'reasonsWeLose', itemIndex, '[]');
     body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
     // Build linking strategy
     const linkingMode = this.getNodeParameter('linkingMode', itemIndex) as string;

--- a/nodes/Octave/actions/competitor/update.operation.ts
+++ b/nodes/Octave/actions/competitor/update.operation.ts
@@ -33,35 +33,35 @@ const properties: INodeProperties[] = [
         description: 'Internal name of the competitor (optional)',
     },
     {
-        displayName: 'Business Model (JSON Array)',
-        name: 'businessModel',
+        displayName: 'How They Position (JSON Array)',
+        name: 'howTheyPosition',
         type: 'json',
         default: '[]',
-        description: 'JSON array of business model descriptions (optional)',
+        description: 'JSON array — how the competitor positions themselves: their narrative, messaging, and market story; the pitch they take to market (optional)',
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Comparative Strengths (JSON Array)',
-        name: 'comparativeStrengths',
+        displayName: 'Our Key Differentiators (JSON Array)',
+        name: 'ourKeyDifferentiators',
         type: 'json',
         default: '[]',
-        description: 'JSON array of comparative strengths (optional)',
+        description: 'JSON array — concrete, observable, tactical points of differentiation we lead with against this competitor (optional)',
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Comparative Weaknesses (JSON Array)',
-        name: 'comparativeWeaknesses',
+        displayName: 'Competitor Strengths (JSON Array)',
+        name: 'competitorStrengths',
         type: 'json',
         default: '[]',
-        description: 'JSON array of comparative weaknesses (optional)',
+        description: 'JSON array — where this competitor genuinely excels (optional)',
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Key Differentiators (JSON Array)',
-        name: 'keyDifferentiators',
+        displayName: 'Competitor Weaknesses (JSON Array)',
+        name: 'competitorWeaknesses',
         type: 'json',
         default: '[]',
-        description: 'JSON array of key differentiators (optional)',
+        description: 'JSON array — where this competitor falls short (optional)',
         typeOptions: { rows: 3 },
     },
     {
@@ -73,19 +73,11 @@ const properties: INodeProperties[] = [
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Customers We Won (JSON Array)',
-        name: 'customersWeWon',
+        displayName: 'Reasons We Lose (JSON Array)',
+        name: 'reasonsWeLose',
         type: 'json',
         default: '[]',
-        description: 'JSON array of customers we won from this competitor (optional)',
-        typeOptions: { rows: 3 },
-    },
-    {
-        displayName: 'Customers We Switched (JSON Array)',
-        name: 'customersWeSwitched',
-        type: 'json',
-        default: '[]',
-        description: 'JSON array of customers we switched to this competitor (optional)',
+        description: 'JSON array — deal-level dynamics for why customers might choose them when both are evaluated (optional)',
         typeOptions: { rows: 3 },
     },
     {
@@ -118,13 +110,12 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.name = this.getNodeParameter('name', itemIndex) as string | undefined;
     body.description = this.getNodeParameter('description', itemIndex) as string | undefined;
     body.internalName = this.getNodeParameter('internalName', itemIndex) as string | undefined;
-    body.businessModel = parseJsonParameter.call(this, 'businessModel', itemIndex, '[]');
-    body.comparativeStrengths = parseJsonParameter.call(this, 'comparativeStrengths', itemIndex, '[]');
-    body.comparativeWeaknesses = parseJsonParameter.call(this, 'comparativeWeaknesses', itemIndex, '[]');
-    body.keyDifferentiators = parseJsonParameter.call(this, 'keyDifferentiators', itemIndex, '[]');
+    body.howTheyPosition = parseJsonParameter.call(this, 'howTheyPosition', itemIndex, '[]');
+    body.ourKeyDifferentiators = parseJsonParameter.call(this, 'ourKeyDifferentiators', itemIndex, '[]');
+    body.competitorStrengths = parseJsonParameter.call(this, 'competitorStrengths', itemIndex, '[]');
+    body.competitorWeaknesses = parseJsonParameter.call(this, 'competitorWeaknesses', itemIndex, '[]');
     body.reasonsWeWin = parseJsonParameter.call(this, 'reasonsWeWin', itemIndex, '[]');
-    body.customersWeWon = parseJsonParameter.call(this, 'customersWeWon', itemIndex, '[]');
-    body.customersWeSwitched = parseJsonParameter.call(this, 'customersWeSwitched', itemIndex, '[]');
+    body.reasonsWeLose = parseJsonParameter.call(this, 'reasonsWeLose', itemIndex, '[]');
     body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
 
     Object.keys(body).forEach(key => (body[key] === undefined) && delete body[key]);

--- a/nodes/Octave/actions/persona/create.operation.ts
+++ b/nodes/Octave/actions/persona/create.operation.ts
@@ -92,6 +92,14 @@ const properties: INodeProperties[] = [
         typeOptions: { rows: 3 },
     },
     {
+        displayName: 'Buying Role (JSON Array)',
+        name: 'buyingRole',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array describing the function this persona plays in a purchase decision (e.g. economic buyer, champion, technical evaluator, end user, influencer, blocker), along with their level of sophistication (newcomer, experienced, expert) (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
         displayName: 'Custom Fields (JSON Array)',
         name: 'customFields',
         type: 'json',
@@ -162,6 +170,7 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.primaryResponsibilities = parseJsonParameter.call(this, 'primaryResponsibilities', itemIndex, '[]');
     body.whyTheyMatterToUs = parseJsonParameter.call(this, 'whyTheyMatterToUs', itemIndex, '[]');
     body.whyWeMatterToThem = parseJsonParameter.call(this, 'whyWeMatterToThem', itemIndex, '[]');
+    body.buyingRole = parseJsonParameter.call(this, 'buyingRole', itemIndex, '[]');
     body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
     // Build linking strategy
     const linkingMode = this.getNodeParameter('linkingMode', itemIndex) as string;

--- a/nodes/Octave/actions/persona/update.operation.ts
+++ b/nodes/Octave/actions/persona/update.operation.ts
@@ -89,6 +89,14 @@ const properties: INodeProperties[] = [
         typeOptions: { rows: 3 },
     },
     {
+        displayName: 'Buying Role (JSON Array)',
+        name: 'buyingRole',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array describing the function this persona plays in a purchase decision (e.g. economic buyer, champion, technical evaluator, end user, influencer, blocker), along with their level of sophistication (newcomer, experienced, expert) (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
         displayName: 'Custom Fields (JSON Array)',
         name: 'customFields',
         type: 'json',
@@ -125,6 +133,7 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.primaryResponsibilities = parseJsonParameter.call(this, 'primaryResponsibilities', itemIndex, '[]');
     body.whyTheyMatterToUs = parseJsonParameter.call(this, 'whyTheyMatterToUs', itemIndex, '[]');
     body.whyWeMatterToThem = parseJsonParameter.call(this, 'whyWeMatterToThem', itemIndex, '[]');
+    body.buyingRole = parseJsonParameter.call(this, 'buyingRole', itemIndex, '[]');
     body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
 
     Object.keys(body).forEach(key => (body[key] === undefined) && delete body[key]);

--- a/nodes/Octave/actions/product/create.operation.ts
+++ b/nodes/Octave/actions/product/create.operation.ts
@@ -51,11 +51,19 @@ const properties: INodeProperties[] = [
         description: 'Primary URL for the product (optional)',
     },
     {
-        displayName: 'Capabilities (JSON Array)',
-        name: 'capabilities',
+        displayName: 'Distinct Capabilities (JSON Array)',
+        name: 'distinctCapabilities',
         type: 'json',
         default: '[]',
-        description: 'JSON array of product capabilities (optional)',
+        description: 'JSON array — what the product does at the functional level: outcome-oriented capabilities, not mechanisms (mechanisms live in keyFeatures) (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
+        displayName: 'Key Features (JSON Array)',
+        name: 'keyFeatures',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array — specific, named, often branded components of the product worth highlighting; the "how" behind the capabilities (optional)',
         typeOptions: { rows: 3 },
     },
     {
@@ -122,7 +130,8 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.summary = this.getNodeParameter('summary', itemIndex) as string | undefined;
     body.internalName = this.getNodeParameter('internalName', itemIndex) as string | undefined;
     body.primaryUrl = this.getNodeParameter('primaryUrl', itemIndex) as string | undefined;
-    body.capabilities = parseJsonParameter.call(this, 'capabilities', itemIndex, '[]');
+    body.distinctCapabilities = parseJsonParameter.call(this, 'distinctCapabilities', itemIndex, '[]');
+    body.keyFeatures = parseJsonParameter.call(this, 'keyFeatures', itemIndex, '[]');
     body.challengesAddressed = parseJsonParameter.call(this, 'challengesAddressed', itemIndex, '[]');
     body.customerBenefits = parseJsonParameter.call(this, 'customerBenefits', itemIndex, '[]');
     body.differentiatedValue = parseJsonParameter.call(this, 'differentiatedValue', itemIndex, '[]');

--- a/nodes/Octave/actions/product/update.operation.ts
+++ b/nodes/Octave/actions/product/update.operation.ts
@@ -58,11 +58,19 @@ const properties: INodeProperties[] = [
         description: 'Primary URL for the product (optional)',
     },
     {
-        displayName: 'Capabilities (JSON Array)',
-        name: 'capabilities',
+        displayName: 'Distinct Capabilities (JSON Array)',
+        name: 'distinctCapabilities',
         type: 'json',
         default: '[]',
-        description: 'JSON array of product capabilities (optional)',
+        description: 'JSON array — what the product does at the functional level: outcome-oriented capabilities, not mechanisms (mechanisms live in keyFeatures) (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
+        displayName: 'Key Features (JSON Array)',
+        name: 'keyFeatures',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array — specific, named, often branded components of the product worth highlighting; the "how" behind the capabilities (optional)',
         typeOptions: { rows: 3 },
     },
     {
@@ -130,7 +138,8 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.summary = this.getNodeParameter('summary', itemIndex) as string | undefined;
     body.internalName = this.getNodeParameter('internalName', itemIndex) as string | undefined;
     body.primaryUrl = this.getNodeParameter('primaryUrl', itemIndex) as string | undefined;
-    body.capabilities = parseJsonParameter.call(this, 'capabilities', itemIndex, '[]');
+    body.distinctCapabilities = parseJsonParameter.call(this, 'distinctCapabilities', itemIndex, '[]');
+    body.keyFeatures = parseJsonParameter.call(this, 'keyFeatures', itemIndex, '[]');
     body.challengesAddressed = parseJsonParameter.call(this, 'challengesAddressed', itemIndex, '[]');
     body.customerBenefits = parseJsonParameter.call(this, 'customerBenefits', itemIndex, '[]');
     body.differentiatedValue = parseJsonParameter.call(this, 'differentiatedValue', itemIndex, '[]');

--- a/nodes/Octave/actions/proofPoint/create.operation.ts
+++ b/nodes/Octave/actions/proofPoint/create.operation.ts
@@ -52,6 +52,22 @@ const properties: INodeProperties[] = [
         description: 'Internal name of the proof point (optional)',
     },
     {
+        displayName: 'The Proof (JSON Array)',
+        name: 'theProof',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array — the complete evidence statement: the actual fact, statistic, claim, metric, achievement or recognition AND where it comes from and when (if available) (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
+        displayName: 'What It Supports (JSON Array)',
+        name: 'whatItSupports',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array — the specific value claims, differentiators, or message this proof point backs up; what links the proof into the broader value story (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
         displayName: 'How We Talk About This (JSON Array)',
         name: 'howWeTalkAboutThis',
         type: 'json',
@@ -60,11 +76,11 @@ const properties: INodeProperties[] = [
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Why This Matters (JSON Array)',
-        name: 'whyThisMatters',
+        displayName: 'Why It Matters (JSON Array)',
+        name: 'whyItMatters',
         type: 'json',
         default: '[]',
-        description: 'JSON array of why this proof point matters (optional)',
+        description: 'JSON array — the strategic frame for why this proof point is compelling: what objection it neutralizes, what doubt it removes, what conviction it builds (optional)',
         typeOptions: { rows: 3 },
     },
     {
@@ -133,8 +149,10 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
 
     body.description = this.getNodeParameter('description', itemIndex) as string | undefined;
     body.internalName = this.getNodeParameter('internalName', itemIndex) as string | undefined;
+    body.theProof = parseJsonParameter.call(this, 'theProof', itemIndex, '[]');
+    body.whatItSupports = parseJsonParameter.call(this, 'whatItSupports', itemIndex, '[]');
     body.howWeTalkAboutThis = parseJsonParameter.call(this, 'howWeTalkAboutThis', itemIndex, '[]');
-    body.whyThisMatters = parseJsonParameter.call(this, 'whyThisMatters', itemIndex, '[]');
+    body.whyItMatters = parseJsonParameter.call(this, 'whyItMatters', itemIndex, '[]');
     body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
     // Build linking strategy
     const linkingMode = this.getNodeParameter('linkingMode', itemIndex) as string;

--- a/nodes/Octave/actions/proofPoint/update.operation.ts
+++ b/nodes/Octave/actions/proofPoint/update.operation.ts
@@ -48,6 +48,22 @@ const properties: INodeProperties[] = [
         description: 'Internal name of the proof point (optional)',
     },
     {
+        displayName: 'The Proof (JSON Array)',
+        name: 'theProof',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array — the complete evidence statement: the actual fact, statistic, claim, metric, achievement or recognition AND where it comes from and when (if available) (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
+        displayName: 'What It Supports (JSON Array)',
+        name: 'whatItSupports',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array — the specific value claims, differentiators, or message this proof point backs up; what links the proof into the broader value story (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
         displayName: 'How We Talk About This (JSON Array)',
         name: 'howWeTalkAboutThis',
         type: 'json',
@@ -56,11 +72,11 @@ const properties: INodeProperties[] = [
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Why This Matters (JSON Array)',
-        name: 'whyThisMatters',
+        displayName: 'Why It Matters (JSON Array)',
+        name: 'whyItMatters',
         type: 'json',
         default: '[]',
-        description: 'JSON array of why this proof point matters (optional)',
+        description: 'JSON array — the strategic frame for why this proof point is compelling: what objection it neutralizes, what doubt it removes, what conviction it builds (optional)',
         typeOptions: { rows: 3 },
     },
     {
@@ -94,8 +110,10 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.type = this.getNodeParameter('type', itemIndex) as string | undefined;
     body.description = this.getNodeParameter('description', itemIndex) as string | undefined;
     body.internalName = this.getNodeParameter('internalName', itemIndex) as string | undefined;
+    body.theProof = parseJsonParameter.call(this, 'theProof', itemIndex, '[]');
+    body.whatItSupports = parseJsonParameter.call(this, 'whatItSupports', itemIndex, '[]');
     body.howWeTalkAboutThis = parseJsonParameter.call(this, 'howWeTalkAboutThis', itemIndex, '[]');
-    body.whyThisMatters = parseJsonParameter.call(this, 'whyThisMatters', itemIndex, '[]');
+    body.whyItMatters = parseJsonParameter.call(this, 'whyItMatters', itemIndex, '[]');
     body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
 
     Object.keys(body).forEach(key => (body[key] === undefined) && delete body[key]);

--- a/nodes/Octave/actions/reference/create.operation.ts
+++ b/nodes/Octave/actions/reference/create.operation.ts
@@ -48,7 +48,7 @@ const properties: INodeProperties[] = [
         type: 'json',
         default: '{}',
         description: 'JSON object containing reference data (optional). Refer to Octave API docs for schema.',
-        placeholder: '{\n  "howTheyMakeMoney": "Subscription-based cloud storage...",\n  "howTheyUseProduct": "Uses our API for integration...",\n  "howTheyBenefitFromProduct": "Improved reliability...",\n  "howWeImpactedTheirBusiness": ["50% cost reduction", "99.9% uptime"],\n  "keyStats": ["100M+ users", "$2B ARR"],\n  "customFields": [{ "title": "Industry", "value": ["SaaS", "Cloud Storage"] }]\n}',
+        placeholder: '{\n  "businessModel": "SaaS platform with subscription revenue model",\n  "theirChallenge": "Manual onboarding bottlenecks were forcing them to cap new-customer growth.",\n  "howTheyUseUs": "Uses our API to integrate with their customer onboarding flow",\n  "whyTheyChoseUs": "Evaluated three vendors but chose us for the API depth and real-time event streaming.",\n  "impactTheySaw": ["Reduced customer onboarding time by 60%", "Cut operational costs by 30%"],\n  "stakeholdersInvolved": ["VP of Customer Success — owned the onboarding KPI", "Head of Engineering — needed an API-first solution"],\n  "customFields": [{ "title": "Industry", "value": ["SaaS", "Cloud Storage"] }]\n}',
         typeOptions: {
             rows: 8,
         },

--- a/nodes/Octave/actions/reference/update.operation.ts
+++ b/nodes/Octave/actions/reference/update.operation.ts
@@ -33,48 +33,51 @@ const properties: INodeProperties[] = [
         description: 'Internal name of the reference (optional)',
     },
     {
-        displayName: 'How We Impacted Their Business (JSON Array)',
-        name: 'howWeImpactedTheirBusiness',
-        type: 'json',
-        default: '[]',
-        description: 'JSON array of how we impacted their business (optional)',
+        displayName: 'Business Model',
+        name: 'businessModel',
+        type: 'string',
+        default: '',
+        description: 'How the customer operates commercially: revenue model, pricing structure, sales motion, and commercial dynamics (optional)',
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'How They Benefit From Product',
-        name: 'howTheyBenefitFromProduct',
+        displayName: 'Their Challenge',
+        name: 'theirChallenge',
         type: 'string',
         default: '',
-        description: 'How they benefit from the product (optional)',
-    },
-    {
-        displayName: 'How They Make Money',
-        name: 'howTheyMakeMoney',
-        type: 'string',
-        default: '',
-        description: 'How they make money (optional)',
-    },
-    {
-        displayName: 'How They Use Product',
-        name: 'howTheyUseProduct',
-        type: 'string',
-        default: '',
-        description: 'How they use the product (optional)',
-    },
-    {
-        displayName: 'Key Stats (JSON Array)',
-        name: 'keyStats',
-        type: 'json',
-        default: '[]',
-        description: 'JSON array of key statistics (optional)',
+        description: 'What was broken before they came to us — the pain, what they had tried that did not work, and what triggered them to look for a better way (optional)',
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Email Snippets (JSON Array)',
-        name: 'emailSnippets',
+        displayName: 'How They Use Us',
+        name: 'howTheyUseUs',
+        type: 'string',
+        default: '',
+        description: 'What they use us for in practice — which offerings they have adopted, how they have embedded them into their workflows, and the role we now play (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
+        displayName: 'Why They Chose Us',
+        name: 'whyTheyChoseUs',
+        type: 'string',
+        default: '',
+        description: 'The decision rationale: alternatives they considered, what made our offering stand out, and the specific factors that tipped them toward us (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
+        displayName: 'Impact They Saw (JSON Array)',
+        name: 'impactTheySaw',
         type: 'json',
         default: '[]',
-        description: 'JSON array of email snippets (optional)',
+        description: 'JSON array — the meaningful change attributable to working with us: qualitative shifts and quantifiable metrics (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
+        displayName: 'Stakeholders Involved (JSON Array)',
+        name: 'stakeholdersInvolved',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array — roles, titles, and personas at the customer who drove and championed the work, and why they cared about this problem (optional)',
         typeOptions: { rows: 3 },
     },
     {
@@ -107,15 +110,15 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.name = this.getNodeParameter('name', itemIndex) as string | undefined;
     body.description = this.getNodeParameter('description', itemIndex) as string | undefined;
     body.internalName = this.getNodeParameter('internalName', itemIndex) as string | undefined;
-    body.howWeImpactedTheirBusiness = parseJsonParameter.call(this, 'howWeImpactedTheirBusiness', itemIndex, '[]');
-    body.howTheyBenefitFromProduct = this.getNodeParameter('howTheyBenefitFromProduct', itemIndex) as string | undefined;
-    body.howTheyMakeMoney = this.getNodeParameter('howTheyMakeMoney', itemIndex) as string | undefined;
-    body.howTheyUseProduct = this.getNodeParameter('howTheyUseProduct', itemIndex) as string | undefined;
-    body.keyStats = parseJsonParameter.call(this, 'keyStats', itemIndex, '[]');
-    body.emailSnippets = parseJsonParameter.call(this, 'emailSnippets', itemIndex, '[]');
+    body.businessModel = this.getNodeParameter('businessModel', itemIndex) as string | undefined;
+    body.theirChallenge = this.getNodeParameter('theirChallenge', itemIndex) as string | undefined;
+    body.howTheyUseUs = this.getNodeParameter('howTheyUseUs', itemIndex) as string | undefined;
+    body.whyTheyChoseUs = this.getNodeParameter('whyTheyChoseUs', itemIndex) as string | undefined;
+    body.impactTheySaw = parseJsonParameter.call(this, 'impactTheySaw', itemIndex, '[]');
+    body.stakeholdersInvolved = parseJsonParameter.call(this, 'stakeholdersInvolved', itemIndex, '[]');
     body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
 
-    Object.keys(body).forEach(key => (body[key] === undefined) && delete body[key]);
+    Object.keys(body).forEach(key => (body[key] === undefined || body[key] === '') && delete body[key]);
 
     const responseData = await octaveApiRequest.call(this, 'PUT', '/api/v2/reference/update', body);
 

--- a/nodes/Octave/actions/segment/update.operation.ts
+++ b/nodes/Octave/actions/segment/update.operation.ts
@@ -33,34 +33,43 @@ const properties: INodeProperties[] = [
         description: 'Internal name of the segment (optional)',
     },
     {
-        displayName: 'Fit Explanation',
-        name: 'fitExplanation',
-        type: 'string',
-        default: '',
-        description: 'Explanation of the fit for this segment (optional)',
-    },
-    {
-        displayName: 'Key Considerations (JSON Array)',
-        name: 'keyConsiderations',
+        displayName: 'Strategic Fit (JSON Array)',
+        name: 'strategicFit',
         type: 'json',
         default: '[]',
-        description: 'JSON array of key considerations (optional)',
+        description: 'JSON array — why this segment matters to us: the fit between what we offer and what they need, and the unique attributes of this segment that align to our offering (optional)',
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Key Priorities (JSON Array)',
-        name: 'keyPriorities',
+        displayName: 'Operating Characteristics (JSON Array)',
+        name: 'operatingCharacteristics',
         type: 'json',
         default: '[]',
-        description: 'JSON array of key priorities (optional)',
+        description: 'JSON array — internal, qualitative, often inferred traits that distinguish this segment: org structure, maturity, operating model, culture (optional)',
         typeOptions: { rows: 3 },
     },
     {
-        displayName: 'Unique Approach (JSON Array)',
-        name: 'uniqueApproach',
+        displayName: 'Buying Dynamics (JSON Array)',
+        name: 'buyingDynamics',
         type: 'json',
         default: '[]',
-        description: 'JSON array of unique approach elements (optional)',
+        description: 'JSON array — how this segment makes and acts on purchasing decisions: what drives evaluation, who is involved, how the process runs, and what signals a likely buyer (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
+        displayName: 'Strategic Priorities (JSON Array)',
+        name: 'strategicPriorities',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array of strategic priorities this segment is pursuing (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
+        displayName: 'Market Pressures (JSON Array)',
+        name: 'marketPressures',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array of market pressures affecting this segment (optional)',
         typeOptions: { rows: 3 },
     },
     {
@@ -68,7 +77,7 @@ const properties: INodeProperties[] = [
         name: 'firmographics',
         type: 'json',
         default: '{}',
-        description: 'Firmographics data (optional)',
+        description: 'Firmographics object: { industry, businessModel, geography, revenue, employees } — supports custom keys (optional)',
         typeOptions: { rows: 3 }
     },
     {
@@ -101,10 +110,11 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.name = this.getNodeParameter('name', itemIndex) as string | undefined;
     body.description = this.getNodeParameter('description', itemIndex) as string | undefined;
     body.internalName = this.getNodeParameter('internalName', itemIndex) as string | undefined;
-    body.fitExplanation = this.getNodeParameter('fitExplanation', itemIndex) as string | undefined;
-    body.keyConsiderations = parseJsonParameter.call(this, 'keyConsiderations', itemIndex, '[]');
-    body.keyPriorities = parseJsonParameter.call(this, 'keyPriorities', itemIndex, '[]');
-    body.uniqueApproach = parseJsonParameter.call(this, 'uniqueApproach', itemIndex, '[]');
+    body.strategicFit = parseJsonParameter.call(this, 'strategicFit', itemIndex, '[]');
+    body.operatingCharacteristics = parseJsonParameter.call(this, 'operatingCharacteristics', itemIndex, '[]');
+    body.buyingDynamics = parseJsonParameter.call(this, 'buyingDynamics', itemIndex, '[]');
+    body.strategicPriorities = parseJsonParameter.call(this, 'strategicPriorities', itemIndex, '[]');
+    body.marketPressures = parseJsonParameter.call(this, 'marketPressures', itemIndex, '[]');
     body.firmographics = parseJsonParameter.call(this, 'firmographics', itemIndex, '{}');
     body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
 

--- a/nodes/Octave/actions/solution/create.operation.ts
+++ b/nodes/Octave/actions/solution/create.operation.ts
@@ -16,7 +16,7 @@ const properties: INodeProperties[] = [
 		name: 'solutionData',
 		type: 'json',
 		default: '{}',
-		description: 'Optional additional fields: internalName, summary, description, capabilities, keyOutcomes, customerBenefits, challengesAddressed, statusQuo, differentiatedValue, customFields',
+		description: 'Optional additional fields: internalName, summary, description, distinctCapabilities, keyComponents, customerBenefits, challengesAddressed, statusQuo, differentiatedValue, customFields',
 		typeOptions: { rows: 6 },
 	},
 	{

--- a/nodes/Octave/actions/solution/update.operation.ts
+++ b/nodes/Octave/actions/solution/update.operation.ts
@@ -17,7 +17,7 @@ const properties: INodeProperties[] = [
 		type: 'json',
 		required: true,
 		default: '{}',
-		description: 'Solution data fields to update (name, internalName, description, qualifyingQuestions, data: {summary, capabilities, keyOutcomes, customerBenefits, challengesAddressed, statusQuo, differentiatedValue, customFields})',
+		description: 'Solution data fields to update (name, internalName, description, qualifyingQuestions, data: {summary, distinctCapabilities, keyComponents, customerBenefits, challengesAddressed, statusQuo, differentiatedValue, customFields})',
 		typeOptions: { rows: 10 },
 	},
 ];

--- a/nodes/Octave/actions/useCase/create.operation.ts
+++ b/nodes/Octave/actions/useCase/create.operation.ts
@@ -74,6 +74,14 @@ const properties: INodeProperties[] = [
         typeOptions: { rows: 3 },
     },
     {
+        displayName: 'Strategic Impact (JSON Array)',
+        name: 'strategicImpact',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array — strategic, business-level benefit realized when this use case is solved well: quantifiable impact on revenue, cost, risk, and/or efficiency, and the broader value to the company (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
         displayName: 'Custom Fields (JSON Array)',
         name: 'customFields',
         type: 'json',
@@ -142,6 +150,7 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.businessDrivers = parseJsonParameter.call(this, 'businessDrivers', itemIndex, '[]');
     body.desiredOutcomes = parseJsonParameter.call(this, 'desiredOutcomes', itemIndex, '[]');
     body.scenarios = parseJsonParameter.call(this, 'scenarios', itemIndex, '[]');
+    body.strategicImpact = parseJsonParameter.call(this, 'strategicImpact', itemIndex, '[]');
     body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
     // Build linking strategy
     const linkingMode = this.getNodeParameter('linkingMode', itemIndex) as string;

--- a/nodes/Octave/actions/useCase/update.operation.ts
+++ b/nodes/Octave/actions/useCase/update.operation.ts
@@ -71,6 +71,14 @@ const properties: INodeProperties[] = [
         typeOptions: { rows: 3 },
     },
     {
+        displayName: 'Strategic Impact (JSON Array)',
+        name: 'strategicImpact',
+        type: 'json',
+        default: '[]',
+        description: 'JSON array — strategic, business-level benefit realized when this use case is solved well: quantifiable impact on revenue, cost, risk, and/or efficiency, and the broader value to the company (optional)',
+        typeOptions: { rows: 3 },
+    },
+    {
         displayName: 'Custom Fields (JSON Array)',
         name: 'customFields',
         type: 'json',
@@ -105,6 +113,7 @@ export async function execute(this: IExecuteFunctions, itemIndex: number): Promi
     body.businessDrivers = parseJsonParameter.call(this, 'businessDrivers', itemIndex, '[]');
     body.desiredOutcomes = parseJsonParameter.call(this, 'desiredOutcomes', itemIndex, '[]');
     body.scenarios = parseJsonParameter.call(this, 'scenarios', itemIndex, '[]');
+    body.strategicImpact = parseJsonParameter.call(this, 'strategicImpact', itemIndex, '[]');
     body.customFields = parseJsonParameter.call(this, 'customFields', itemIndex, '[]');
 
     Object.keys(body).forEach(key => (body[key] === undefined) && delete body[key]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-octavehq",
-  "version": "1.6.3",
+  "version": "1.6.5",
   "description": "Octave is the AI-powered messaging brain for B2B go-to-market teams, helping articulate product value, synthesize customer interaction data, and deploy consistent, effective messaging across all channels.",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
Sync n8n property declarations with octave-app library entity schema refresh: rename fields (e.g. whatsTheCostOfInaction→costOfInaction, capabilities→ distinctCapabilities, whyThisMatters→whyItMatters), drop removed fields, and expose newly-added fields (keyFeatures, theProof, whatItSupports, howTheyPosition, reasonsWeLose, buyingRole, strategicImpact, strategicFit, operatingCharacteristics, buyingDynamics, etc.) across buyingTrigger, useCase, persona, product, solution, proofPoint, segment, competitor, and reference. Bump to 1.7.0 since saved workflows that set renamed fields will silently lose data on the API side.